### PR TITLE
bump Scala, sbt, ScalaTest versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,12 @@ organization := "com.github.takezoe"
 
 version := "1.0.2"
 
-crossScalaVersions := Seq("2.13.3", "2.12.12")
+crossScalaVersions := Seq("2.13.4", "2.12.12")
 scalaVersion := crossScalaVersions.value.head
 
 libraryDependencies ++= Seq(
   scalaOrganization.value % "scala-compiler" % scalaVersion.value,
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+  "org.scalatest" %% "scalatest" % "3.2.3" % Test,
 )
 Test / scalacOptions ++= {
   val jar = (Compile / packageBin).value
@@ -30,7 +30,7 @@ publishTo := {
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 
 pomIncludeRepository := { _ => false }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.4

--- a/src/test/scala/TestSpec.scala
+++ b/src/test/scala/TestSpec.scala
@@ -1,8 +1,8 @@
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import com.github.takezoe.scaladoc.Scaladoc
 
-class SetSuite extends FunSuite {
+class SetSuite extends AnyFunSuite {
 
   test("class scaladoc") {
     val clazz = classOf[HelloWorld]


### PR DESCRIPTION
context: in the Scala community build, we prefer ScalaTest 3.2 to 3.0. then the rest is just stuff I noticed would be nice to also bump.