### PR TITLE
Support object

### DIFF
--- a/src/main/scala/com/github/takezoe/scaladoc/EmbedScaladocAnnotationPlugin.scala
+++ b/src/main/scala/com/github/takezoe/scaladoc/EmbedScaladocAnnotationPlugin.scala
@@ -70,6 +70,20 @@ class EmbedScaladocAnnotationPlugin(val global: Global) extends Plugin {
               case None => x
             }
           }
+          case x @ ModuleDef(_, _, _) => {
+            comments.getComment(x.pos) match {
+              case Some(comment) =>
+                val newAnnotations = createAnnotation(comment) :: x.mods.annotations
+                val newMods = x.mods.copy(annotations = newAnnotations)
+                val newBody = x.impl.body.map(transform)
+                val newImpl = global.treeCopy.Template(x.impl, x.impl.parents, x.impl.self, newBody)
+                global.treeCopy.ModuleDef(tree, newMods, x.name, newImpl)
+              case None =>
+                val newBody = x.impl.body.map(transform)
+                val newImpl = global.treeCopy.Template(x.impl, x.impl.parents, x.impl.self, newBody)
+                global.treeCopy.ModuleDef(tree, x.mods, x.name, newImpl)
+            }
+          }
           case x => super.transform(x)
         }
       }

--- a/src/test/scala/TestSpec.scala
+++ b/src/test/scala/TestSpec.scala
@@ -1,5 +1,5 @@
+import HelloWorld.InnerObject
 import org.scalatest.funsuite.AnyFunSuite
-
 import com.github.takezoe.scaladoc.Scaladoc
 
 class SetSuite extends AnyFunSuite {
@@ -13,12 +13,20 @@ class SetSuite extends AnyFunSuite {
                         |  */""".stripMargin)
   }
 
+  test("object scaladoc") {
+    val clazz = HelloWorld.getClass
+    val scaladoc = clazz.getAnnotation(classOf[Scaladoc])
+    val comment: String = scaladoc.value()
+    assert(comment == """/**
+                        |  * Hello, Companion!
+                        |  */""".stripMargin)
+  }
+
   test("field scaladoc") {
     val clazz = classOf[HelloWorld]
     val field = clazz.getDeclaredField("field")
     val scaladoc = field.getAnnotation(classOf[Scaladoc])
     val comment: String = scaladoc.value()
-    println(comment)
     assert(comment == """/**
                         |    * field
                         |    */""".stripMargin)
@@ -29,10 +37,23 @@ class SetSuite extends AnyFunSuite {
     val method = clazz.getDeclaredMethod("method")
     val scaladoc = method.getAnnotation(classOf[Scaladoc])
     val comment: String = scaladoc.value()
-    println(comment)
     assert(comment == """/**
                         |    * method
                         |    */""".stripMargin)
+  }
+
+  test("inner class scaladoc") {
+    val clazz = classOf[HelloWorld.InnerClass]
+    val scaladoc = clazz.getAnnotation(classOf[Scaladoc])
+    val comment: String = scaladoc.value()
+    assert(comment == """/** Inner class comment */""".stripMargin)
+  }
+
+  test("inner object scaladoc") {
+    val clazz = HelloWorld.InnerObject.getClass
+    val scaladoc = clazz.getAnnotation(classOf[Scaladoc])
+    val comment: String = scaladoc.value()
+    assert(comment == """/** Inner object comment */""".stripMargin)
   }
 
 }
@@ -53,4 +74,15 @@ class HelloWorld {
   def method(): Unit = {
   }
 
+}
+
+/**
+  * Hello, Companion!
+  */
+object HelloWorld {
+  /** Inner class comment */
+  class InnerClass()
+
+  /** Inner object comment */
+  case object InnerObject {}
 }


### PR DESCRIPTION
Currently, only classes, fields and methods are supported. If we use scaladoc for objects, it is ignored by the plugin.

This commit adds support for objects and tests support for nested classes and objects.